### PR TITLE
Added user-provided email and username

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # README Generator
+  ## Description
+  
+
+  ## Installation
+  
+
+  ## Usage
+  
+
+  ## Credits
+  
+
+  ## Features
+  
+
+  ## Questions
+  If you have any questions then please reach out to me on Github at https://github.com/AegeanGrey or by sending an email at test@sample.com
   

--- a/index.js
+++ b/index.js
@@ -11,6 +11,11 @@ const run = process.argv[2];
 const questions = [
   {
     type: 'input',
+    name: 'username',
+    message: 'What is your GitHub Username?',
+  },
+  {
+    type: 'input',
     name: 'title',
     message: 'What is the title of your project?',
   },
@@ -36,7 +41,7 @@ const questions = [
   },
   {
     type: 'input',
-    name: 'contact',
+    name: 'email',
     message: 'What is the best email to contact you regarding further questions?',
   },
 ];

--- a/utils/generateREADME.js
+++ b/utils/generateREADME.js
@@ -2,6 +2,23 @@
 // returns data to 'fileText' constant
 function generateREADME(response) {
   return `# ${response.title}
+  ## Description
+  
+
+  ## Installation
+  
+
+  ## Usage
+  
+
+  ## Credits
+  
+
+  ## Features
+  
+
+  ## Questions
+  If you have any questions then please reach out to me on Github at ${"https://github.com/" + response.username} or by sending an email at ${response.email}
   
 `;
 }


### PR DESCRIPTION
I've modified the following to the repository so it can now reflect the users email and GitHub webpage from their username onto the README file:

Index.js:
- Added input type labeled 'username' in 'questions' that displays 'What is your GitHub username?' in the console (Lines 12-16).
- Relabeled 'contact' to 'email' (Line 39 now Line 44).

generateREADME.js:
- Added Sections that will correlate with user inputs for the README file in future pushes (Description, Installation, Usage, Credits, Features and Questions)
- Added Template Literals within 'Questions' section that will create a link to the users GitHub webpage by concatenating 'https://github.com/' with the users inputted username 'response.username' (Line 21).
- As well as for the users inputted email for contacting regarding further questions.